### PR TITLE
Uses a more restrictive regex to find story numbers

### DIFF
--- a/lib/git_tracker/branch.rb
+++ b/lib/git_tracker/branch.rb
@@ -4,7 +4,7 @@ require 'git_tracker/repository'
 module GitTracker
   module Branch
     def self.story_number
-      current[/#?(\d+)/, 1]
+      current[/#?(\d{6,10})/, 1]
     end
 
     def self.current

--- a/spec/git_tracker/branch_spec.rb
+++ b/spec/git_tracker/branch_spec.rb
@@ -46,6 +46,18 @@ describe GitTracker::Branch do
         stub_branch('refs/heads/stevenharman/got-her-number-8675309')
         expect(branch.story_number).to eq('8675309')
       end
+      
+      it 'finds the story in a branch with a version number' do
+        stub_branch('refs/heads/stevenharman/v2.0-got-her-number-8675309')
+        expect(branch.story_number).to eq('8675309')
+      end
+    end
+
+    context 'The current branch has a number that is not a story' do
+      it 'finds no story' do
+        stub_branch('refs/heads/a_very_descriptive_name_with_some_a_version_number_v2.0')
+        expect(branch.story_number).to_not be
+      end
     end
 
     context 'The current branch does not have a story number' do


### PR DESCRIPTION
This prevents issues where version numbers are mistakenly captured
and used as the story number.
