### PR TITLE
Check for git-tracker in hook before calling it

### DIFF
--- a/git_tracker.gemspec
+++ b/git_tracker.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'pry', '~> 0.10.1'
   # Use Rake < 10.2 (requires Ruby 1.9+) until we drop Ruby 1.8.7 support
   gem.add_development_dependency 'rake', '~> 10.1.1'
+  # Use json < 2.0 (requires Ruby 2.0+) until we drop Ruby < 2.0 support
+  gem.add_development_dependency "json", "< 2" if RUBY_VERSION < "2"
 
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/git_tracker/hook.rb
+++ b/lib/git_tracker/hook.rb
@@ -29,7 +29,9 @@ module GitTracker
       return <<-HOOK
 #!/usr/bin/env bash
 
-git-tracker prepare-commit-msg "$@"
+if command -v git-tracker >/dev/null; then
+    git-tracker prepare-commit-msg "$@"
+fi
 
       HOOK
     end

--- a/prepare-commit-msg.example
+++ b/prepare-commit-msg.example
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
-git-tracker prepare-commit-msg "$@"
+if command -v git-tracker >/dev/null; then
+    git-tracker prepare-commit-msg "$@"
+fi
 

--- a/spec/git_tracker/hook_spec.rb
+++ b/spec/git_tracker/hook_spec.rb
@@ -39,7 +39,9 @@ describe GitTracker::Hook do
       hook_code = <<-HOOK_CODE.strip_heredoc
         #!/usr/bin/env bash
 
-        git-tracker prepare-commit-msg "$@"
+        if command -v git-tracker >/dev/null; then
+            git-tracker prepare-commit-msg "$@"
+        fi
 
       HOOK_CODE
 


### PR DESCRIPTION
git_tracker makes some GUI git clients (e.g. GitHub Desktop) unable to commit. This allows those clients to commit once again by checking for the existence of git-tracker before calling it in the hook.

Also specifies an older version of `json` for Ruby < 2, which I needed to do in order to pass CI.

Please let me know if you need any additional tests written for this.